### PR TITLE
fix: fuso horário ao formatar data de PDI

### DIFF
--- a/src/services/pdiService.ts
+++ b/src/services/pdiService.ts
@@ -32,7 +32,8 @@ export class PdiService {
     });
     const averages = pdi.secoes.map((secao) => Number(secao.media));
     const registrationDate = new Date(pdi.dataCriacao).toLocaleDateString(
-      'pt-BR'
+      'pt-BR',
+      { timeZone: 'America/Sao_Paulo' }
     );
 
     return {
@@ -165,7 +166,9 @@ export class PdiService {
 
     return pdis.map((pdi: PDI) => ({
       id: pdi.id,
-      registrationDate: new Date(pdi.dataCriacao).toLocaleDateString('pt-BR')
+      registrationDate: new Date(pdi.dataCriacao).toLocaleDateString('pt-BR', {
+        timeZone: 'America/Sao_Paulo'
+      })
     }));
   }
 


### PR DESCRIPTION
- Anteriormente, PDIs criados tarde da noite exibiam a data do dia seguinte. A formatação da data foi ajustada para considerar o fuso horário 'America/Sao_Paulo', garantindo que a data exibida represente corretamente o horário local no momento da criação.